### PR TITLE
Make the variant property optional

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -14,11 +14,9 @@ const checkboxVariants = cva('',{
   }
 });
 
-export interface CheckboxProps
-  extends Omit<CheckboxVariantProps, 'variant'>,
-  Required<Pick<CheckboxVariantProps, 'variant'>> {
-    className?: string;
-  }
+export interface CheckboxProps extends CheckboxVariantProps {
+  className?: string;
+}
 
 const CheckboxRoot = forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,


### PR DESCRIPTION
Since the variant already has a default value, I made this property optional, otherwise the component would start requiring the presence of this property even when there was no need to change the variant.