### PR TITLE
refactor: remove depracated ElementRef

### DIFF
--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -7,7 +7,7 @@ const defaultContextValue:AccordionProps  = {variant : "default", fancy : true};
 const Context = React.createContext<AccordionProps>(defaultContextValue);
 
 const AccordionRoot = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Root>,
+  React.ComponentRef<typeof AccordionPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Root> & AccordionProps
   >(({ className, variant, fancy, ...props }, forwardedRef) => {
   const { root } = accordion({variant});
@@ -23,7 +23,7 @@ const AccordionRoot = React.forwardRef<
 });
 
 const AccordionItem = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> & AccordionProps
   >(({ className, fancy, ...props }, forwardedRef) => {
   
@@ -46,7 +46,7 @@ const AccordionItem = React.forwardRef<
 });
 
 const AccordionTrigger = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({className, children, ...props}, forwardedRef) => {
   const {variant} = React.useContext(Context);
@@ -69,7 +69,7 @@ const AccordionTrigger = React.forwardRef<
 });
 
 const AccordionContent = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentRef<typeof AccordionPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({className, children, ...props}, forwardedRef) => {
   const {variant} = React.useContext(Context);

--- a/src/components/alert_dialog/AlertDialog.tsx
+++ b/src/components/alert_dialog/AlertDialog.tsx
@@ -23,7 +23,7 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
   >(({ className, ...props }, forwardedRef) => {
     const { overlay } = dialog()
@@ -38,7 +38,7 @@ const AlertDialogOverlay = React.forwardRef<
 })
 
 const AlertDialogContent = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & DialogProps
   >(({ className, mixed, fancy, ...props }, forwardedRef) => {
   
@@ -58,7 +58,7 @@ const AlertDialogContent = React.forwardRef<
 });
 
 const AlertDialogTitle = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title> & {
     size?: TitleSizeProp,
     align?: TextAlignProp,
@@ -82,7 +82,7 @@ const AlertDialogTitle = React.forwardRef<
 });
 
 const AlertDialogDescription = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentRef<typeof AlertDialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description> & TextProps & {
     size?: TextSizeProp,
     align?: TextAlignProp,
@@ -109,7 +109,7 @@ const AlertDialogCancel = AlertDialogPrimitive.Cancel;
 const AlertDialogAction = AlertDialogPrimitive.Action;
 
 const AlertDialogActions = React.forwardRef<
-  React.ElementRef<"div">,
+  React.ComponentRef<"div">,
   React.ComponentPropsWithoutRef<"div">
   >(({ className, ...props }, forwardedRef) => {
   const { actions } = dialog()

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { avatar, fallback, image, type AvatarRootProps, type AvatarFallbackProps } from "@tailus/themer";
 
 const AvatarRoot = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentRef<typeof AvatarPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> & AvatarRootProps
   >(({ className, size = "md", status = "online", bottomStatus = false, topStatus = false, ...props }, ref) => {
 
@@ -19,7 +19,7 @@ const AvatarRoot = React.forwardRef<
 });
 
 const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentRef<typeof AvatarPrimitive.Fallback>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback> & AvatarFallbackProps
 >(({className, variant = "solid", intent="primary", ...props}, ref) => {
   return (
@@ -32,7 +32,7 @@ const AvatarFallback = React.forwardRef<
 });
 
 const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({className, ...props}, ref) => {
   return (

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ export interface CheckboxProps extends CheckboxVariants {
 }
 
 const CheckboxRoot = forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & CheckboxProps
   >(({ className, intent, fancy, ...props }: CheckboxProps, forwardedRef) => {
     const classes = fancy ? fancyCheckbox({ intent, className }) : checkbox({ intent, className });

--- a/src/components/context_menu/ContextMenu.tsx
+++ b/src/components/context_menu/ContextMenu.tsx
@@ -23,7 +23,7 @@ const ContextMenuSub = ContextMenuPrimitive.Sub;
 export interface ContextMenuContentProps extends MenuProps { }
 
 const ContextMenuTrigger = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Trigger>,
+  React.ComponentRef<typeof ContextMenuPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Trigger>
   >((props, forwardedRef) => {
     const {trigger} = menu.solid({intent:"primary"});
@@ -37,7 +37,7 @@ const ContextMenuTrigger = React.forwardRef<
 });
 
 const ContextMenuContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content> & ContextMenuContentProps
   >(({ className, variant, intent, mixed, fancy, ...props }, forwardedRef) => {
     
@@ -70,7 +70,7 @@ const ContextMenuContent = React.forwardRef<
 });
 
 const ContextMenuItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentRef<typeof ContextMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & MenuProps
 >((
   {
@@ -103,7 +103,7 @@ interface ContextMenuSubTriggerProps extends MenuProps {
 }
 
 const ContextMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentRef<typeof ContextMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & ContextMenuSubTriggerProps
 >((
   {
@@ -135,7 +135,7 @@ interface ContextMenuSubContentProps extends ContextMenuContentProps {
 }
 
 const ContextMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent> & ContextMenuSubContentProps
 >((
   {
@@ -168,7 +168,7 @@ const ContextMenuSubContent = React.forwardRef<
 interface ContextMenuSeparatorProps extends SeparatorProps {}
 
 const ContextMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator> & ContextMenuSeparatorProps
 >(({className, fancy, dashed, ...props}, forwardedRef) => {
   const {fancy: contextVariant} = React.useContext(MenuContext);
@@ -186,7 +186,7 @@ const ContextMenuSeparator = React.forwardRef<
 });
 
 const ContextMenuCommand = React.forwardRef<
-  React.ElementRef<"div">,
+  React.ComponentRef<"div">,
   React.ComponentPropsWithoutRef<"div"> & ContextMenuContentProps
 >(({className, ...props}, forwardedRef) => {
   const { command } = menu.solid({});
@@ -200,7 +200,7 @@ const ContextMenuCommand = React.forwardRef<
 });
 
 const ContextMenuIcon = React.forwardRef<
-  React.ElementRef<"div">,
+  React.ComponentRef<"div">,
   React.ComponentPropsWithoutRef<"div"> & ContextMenuContentProps
 >(({className, ...props}, forwardedRef) => {
   const { icon } = menu.solid({});

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -19,7 +19,7 @@ const DialogPortal = DialogPrimitive.Portal;
 const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
   React.ComponentProps<typeof DialogPrimitive.Overlay>
   >(({ className, ...props }, forwardedRef) => {
     
@@ -35,7 +35,7 @@ const DialogOverlay = React.forwardRef<
   });
 
 const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentRef<typeof DialogPrimitive.Content>,
   React.ComponentProps<typeof DialogPrimitive.Content> & DialogProps
   >(({ className, fancy, mixed, ...props }, forwardedRef) => {
     const { content } = dialog()
@@ -54,7 +54,7 @@ const DialogContent = React.forwardRef<
   });
 
 const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentRef<typeof DialogPrimitive.Title>,
   React.ComponentProps<typeof DialogPrimitive.Title> & {
     size?: TitleSizeProp,
     align?: TextAlignProp,
@@ -76,7 +76,7 @@ const DialogTitle = React.forwardRef<
 ));
 
 const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentRef<typeof DialogPrimitive.Description>,
   React.ComponentProps<typeof DialogPrimitive.Description> & TextProps & {
     size?: TextSizeProp,
     align?: TextAlignProp,
@@ -99,7 +99,7 @@ const DialogDescription = React.forwardRef<
 ));
 
 const DialogActions = React.forwardRef<
-  React.ElementRef<"div">,
+  React.ComponentRef<"div">,
   React.ComponentProps<"div">
   >(({ className, ...props }, forwardedRef) => {
       const { actions } = dialog()

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -21,7 +21,7 @@ const NestedRoot = Primitive.NestedRoot;
 const DirectionContext = React.createContext<Omit<DrawerProps, "fancy" | "mixed">>({ direction: "bottom", withControler:true });
 
 type RootProps = React.ComponentProps<typeof Primitive.Root> & DrawerProps & {
-    ref?: React.Ref<React.ElementRef<typeof Primitive.Root>>;
+    ref?: React.Ref<React.ComponentRef<typeof Primitive.Root>>;
 };
 
 const Root: React.FC<RootProps> = ({ direction, withControler, ...props }, forwardedRef) => {
@@ -33,7 +33,7 @@ const Root: React.FC<RootProps> = ({ direction, withControler, ...props }, forwa
 };
 
 const Content = React.forwardRef <
-    React.ElementRef < typeof Primitive.Content > ,
+    React.ComponentRef < typeof Primitive.Content > ,
     React.ComponentProps < typeof Primitive.Content > & Omit<DrawerProps, "direction"> 
     >(({
         className,
@@ -58,7 +58,7 @@ const Content = React.forwardRef <
 );
 
 const Overlay = React.forwardRef<
-  React.ElementRef<typeof Primitive.Overlay>,
+  React.ComponentRef<typeof Primitive.Overlay>,
   React.ComponentProps<typeof Primitive.Overlay>
   >(({ className, ...props }, forwardedRef) => {
     
@@ -74,7 +74,7 @@ const Overlay = React.forwardRef<
   });
 
 const Title = React.forwardRef<
-  React.ElementRef<typeof Primitive.Title>,
+  React.ComponentRef<typeof Primitive.Title>,
   React.ComponentProps<typeof Primitive.Title> & {
     size?: TitleSizeProp,
     align?: TextAlignProp,
@@ -89,7 +89,7 @@ const Title = React.forwardRef<
 ));
 
 const Description = React.forwardRef<
-  React.ElementRef<typeof Primitive.Description>,
+  React.ComponentRef<typeof Primitive.Description>,
   React.ComponentProps<typeof Primitive.Description> & TextProps & {
     size?: TextSizeProp,
     align?: TextAlignProp,

--- a/src/components/dropdown_menu/DropdownMenu.tsx
+++ b/src/components/dropdown_menu/DropdownMenu.tsx
@@ -22,7 +22,7 @@ const DropdownMenuItemIndicator = DropdownMenuPrimitive.ItemIndicator;
 const MenuContext = React.createContext(defaultMenuProps);
 
 const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & MenuProps
   >(({ className, variant, intent, mixed, fancy, ...props }, forwardedRef) => {
 
@@ -57,7 +57,7 @@ const DropdownMenuContent = React.forwardRef<
 const DropdownMenuArrow = DropdownMenuPrimitive.Arrow;
 
 const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & MenuProps
   >(({ className, variant, intent, ...props }, forwardedRef) => {
   
@@ -78,7 +78,7 @@ const DropdownMenuItem = React.forwardRef<
 });
 
 const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & SeparatorProps
   >(({ className, fancy, dashed, ...props }, forwardedRef) => {
 
@@ -99,7 +99,7 @@ const DropdownMenuSeparator = React.forwardRef<
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & MenuProps
   >(({ className, variant, intent, ...props }, forwardedRef) => {
   
@@ -119,7 +119,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
 });
 
 const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> & MenuProps
   >(({ className, variant, intent, fancy, mixed, ...props }, forwardedRef) => {
 
@@ -161,7 +161,7 @@ const DropdownMenuIcon = ({className, children}: DropdownMenuIconProps) => {
 }
 
 const DropdownMenuRightIcon = React.forwardRef<
-  React.ElementRef<"div">,
+  React.ComponentRef<"div">,
   React.ComponentPropsWithoutRef<"div"> & MenuProps
 >(({className, ...props}, forwardedRef) => {
   const {icon} = menu.solid({})

--- a/src/components/form/Field.tsx
+++ b/src/components/form/Field.tsx
@@ -13,7 +13,7 @@ export interface FormFieldProps extends LabelProps {
 export const FormContext = createContext<LabelProps>({});
 
 const FormField = React.forwardRef<
-    React.ElementRef<typeof Field>,
+    React.ComponentRef<typeof Field>,
     React.ComponentPropsWithoutRef<typeof Field> & FormFieldProps
   >(({ className, size="md", floating, asTextarea, name, variant="mixed", ...props }, forwardedRef) => {
 

--- a/src/components/form/Label.tsx
+++ b/src/components/form/Label.tsx
@@ -12,7 +12,7 @@ export interface FormLabelProps extends LabelProps {
 }
 
 const FormLabel = React.forwardRef<
-  React.ElementRef<typeof Label>,
+  React.ComponentRef<typeof Label>,
   React.ComponentPropsWithoutRef<typeof Label> & FormLabelProps
   >(({ className, floating, variant, size="md", ...props }, forwardedRef) => {
 

--- a/src/components/form/Message.tsx
+++ b/src/components/form/Message.tsx
@@ -10,7 +10,7 @@ export interface FormMessageProps extends MessageProps{
 }
 
 const FormMessage = React.forwardRef<
-  React.ElementRef<typeof Message>,
+  React.ComponentRef<typeof Message>,
   React.ComponentPropsWithoutRef<typeof Message> & FormMessageProps
   >(({ className, size = "sm", ...props }, forwardedRef) => {
     const { message } = form()

--- a/src/components/form/Root.tsx
+++ b/src/components/form/Root.tsx
@@ -2,7 +2,7 @@ import {Root} from "@radix-ui/react-form";
 import React from "react";
 
 const FormRoot = React.forwardRef<
-React.ElementRef<typeof Root>,
+React.ComponentRef<typeof Root>,
 React.ComponentPropsWithoutRef<typeof Root>
 >(({className, ...props}, forwardedRef) => (
     <Root

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -10,7 +10,7 @@ export interface FormLabelProps extends LabelProps {
 }
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & FormLabelProps
   >(({ className,floating, variant, asTextarea, size = "md", ...props }, forwardedRef) => {
   

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -8,7 +8,7 @@ const PopoverAnchor = Popover.Anchor;
 const PopoverPortal = Popover.Portal;
 
 const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof Popover.Content>,
+  React.ComponentRef<typeof Popover.Content>,
   React.ComponentPropsWithoutRef<typeof Popover.Content> & PopoverProps
   >(({ className, fancy, mixed, ...props }, forwardedRef) => {
 
@@ -28,7 +28,7 @@ const PopoverContent = React.forwardRef<
 });
 
 const PopoverClose = React.forwardRef<
-  React.ElementRef<typeof Popover.Close>,
+  React.ComponentRef<typeof Popover.Close>,
   React.ComponentPropsWithoutRef<typeof Popover.Close>
   >(({ className, ...props }, forwardedRef) => {
 
@@ -44,7 +44,7 @@ const PopoverClose = React.forwardRef<
   });
 
 const PopoverArrow = React.forwardRef<
-  React.ElementRef<typeof Popover.Arrow>,
+  React.ComponentRef<typeof Popover.Arrow>,
   React.ComponentPropsWithoutRef<typeof Popover.Arrow>
   >(({ className, ...props }, forwardedRef) => {
     const { arrow } = popover()

--- a/src/components/progress/Progress.tsx
+++ b/src/components/progress/Progress.tsx
@@ -5,7 +5,7 @@ import { progress, type RootProps, type IndicatorProps as IndicatorVariants } fr
 const { root, indicator } = progress();
 
 const ProgressRoot = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & RootProps
   >(({ className, size="md", variant="soft", ...props}, forwardedRef) => {
 
@@ -27,7 +27,7 @@ const ProgressRoot = React.forwardRef<
 interface IndicatorProps extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Indicator>, IndicatorVariants {}
 
 const ProgressIndicator = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Indicator>,
+  React.ComponentRef<typeof ProgressPrimitive.Indicator>,
   IndicatorProps
   >(({
     className,

--- a/src/components/radio_group/RadioGroup.tsx
+++ b/src/components/radio_group/RadioGroup.tsx
@@ -10,7 +10,7 @@ export interface RadioRootProps extends RadioProps {
 const RadioGroupContext = React.createContext<RadioRootProps>({fancy: false, intent: "primary"});
 
 const RadioGroupRoot = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentRef<typeof RadioGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & RadioRootProps
   >(({ className, intent="primary", fancy=false, ...props }, forwardedRef) => {
   
@@ -32,7 +32,7 @@ export interface RadioItemProps {
 }
 
 const RadioGroupItem = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentRef<typeof RadioGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> & RadioItemProps
   >((props, forwardedRef) => {
     const {intent, fancy} = useContext(RadioGroupContext);
@@ -47,7 +47,7 @@ const RadioGroupItem = React.forwardRef<
 });
 
 const RadioGroupIndicator = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Indicator>,
+  React.ComponentRef<typeof RadioGroupPrimitive.Indicator>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Indicator> & RadioProps & {
     className?: string;
   }

--- a/src/components/scroll_area/ScrollArea.tsx
+++ b/src/components/scroll_area/ScrollArea.tsx
@@ -5,7 +5,7 @@ import { scrollArea } from "@tailus/themer"
 const {root, bar, thumb} = scrollArea()
 
 const ScrollAreaRoot = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentProps<typeof ScrollAreaPrimitive.Root>
 >((props, forwardedRef) => (
   <ScrollAreaPrimitive.Root
@@ -18,7 +18,7 @@ const ScrollAreaRoot = React.forwardRef<
 const ScrollAreaViewport = ScrollAreaPrimitive.Viewport;
 
 const ScrollAreaScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Scrollbar>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.Scrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
 >((
   {
@@ -44,7 +44,7 @@ const ScrollAreaScrollBar = React.forwardRef<
 ScrollAreaScrollBar.displayName = ScrollAreaPrimitive.Scrollbar.displayName;
 
 const ScrollAreaThumb = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Thumb>,
+  React.ComponentRef<typeof ScrollAreaPrimitive.Thumb>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Thumb>
 >((props, forwardedRef) => (
   <ScrollAreaPrimitive.Thumb

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -22,7 +22,7 @@ const SelectContext = React.createContext<SelectProps>({});
 const { button, separator, itemIndicator, label } = select.soft()
 
 const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
 >(({className, children, ...props}, forwardedRef) => (
   <SelectPrimitive.ScrollUpButton
@@ -35,7 +35,7 @@ const SelectScrollUpButton = React.forwardRef<
 ));
 
 const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
 >(({className, children, ...props}, forwardedRef) => (
   <SelectPrimitive.ScrollDownButton
@@ -48,7 +48,7 @@ const SelectScrollDownButton = React.forwardRef<
 ));
 
 const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & TriggerProps
 >(({size, variant, className, children, ...props}, forwardedRef) => {
   const { parent } = trigger()
@@ -69,7 +69,7 @@ const SelectTriggerIcon = ({ className, size, children }: SelectIconProps) => {
 };
 
 const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & SelectProps
   >(({ className, variant, intent, mixed, fancy, children, ...props }, forwardedRef) => {
 
@@ -103,7 +103,7 @@ const SelectContent = React.forwardRef<
   });
 
 const SelectItemIndicator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ItemIndicator>,
+  React.ComponentRef<typeof SelectPrimitive.ItemIndicator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ItemIndicator>
 >(({className, ...props}, forwardedRef) => (
   <SelectPrimitive.ItemIndicator
@@ -114,7 +114,7 @@ const SelectItemIndicator = React.forwardRef<
 ));
 
 const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & SelectProps
   >(({ className, variant, children, ...props }, forwardedRef) => {
 
@@ -139,7 +139,7 @@ const SelectItem = React.forwardRef<
   });
 
 const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({className, ...props}, forwardedRef) => (
   <SelectPrimitive.Label
@@ -150,7 +150,7 @@ const SelectLabel = React.forwardRef<
 ));
 
 const SelectGroup = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Group>,
+  React.ComponentRef<typeof SelectPrimitive.Group>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Group>
 >(({children, ...props}, forwardedRef) => (
   <SelectPrimitive.Group
@@ -162,7 +162,7 @@ const SelectGroup = React.forwardRef<
 ));
 
 const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & Pick<SeparatorProps, "fancy" | "dashed">
   >(({ className, fancy, dashed, ...props }, forwardedRef) => {
 

--- a/src/components/separator/Separator.tsx
+++ b/src/components/separator/Separator.tsx
@@ -5,7 +5,7 @@ import React from "react";
 interface SeparatorVariantProps extends React.ComponentProps<typeof SeparatorPrimitive.Root>, Pick<SeparatorProps, "fancy" | "dashed"> {}
   
 const SeparatorRoot = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> & SeparatorVariantProps
   >(({ fancy, dashed, className, ...props }, ref) => {
     

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -6,7 +6,7 @@ import { slider, type SliderProps, type SliderTrackProps } from "@tailus/themer"
 const SliderContext = createContext<SliderProps>({})
 
 const SliderRoot = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentRef<typeof SliderPrimitive.Root>,
   React.ComponentProps<typeof SliderPrimitive.Root> & Omit<SliderProps, "variant">
   >(({ intent="primary", size="md", className, ...props }, forwardedRef) => {
     const { root } = slider()
@@ -22,7 +22,7 @@ const SliderRoot = React.forwardRef<
 });
 
 const SliderThumb = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.SliderThumb>,
+  React.ComponentRef<typeof SliderPrimitive.SliderThumb>,
   React.ComponentProps<typeof SliderPrimitive.SliderThumb> & Omit<SliderProps, "intent">
   >(({ variant="raised", size="md", className, ...props }, forwardedRef) => {
 
@@ -42,7 +42,7 @@ const SliderThumb = React.forwardRef<
   });
 
 const SliderTrack = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Track>,
+  React.ComponentRef<typeof SliderPrimitive.Track>,
   React.ComponentProps<typeof SliderPrimitive.Track> & SliderTrackProps
   >(({ className, variant="soft", ...props }, forwardedRef) => {
 
@@ -58,7 +58,7 @@ const SliderTrack = React.forwardRef<
 });
 
 const SliderRange = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Range>,
+  React.ComponentRef<typeof SliderPrimitive.Range>,
   React.ComponentProps<typeof SliderPrimitive.Range> & SliderProps 
   >(({ intent, className, ...props }, forwardedRef) => {
 

--- a/src/components/switch/Switch.tsx
+++ b/src/components/switch/Switch.tsx
@@ -9,7 +9,7 @@ const SwitchContext = React.createContext<SwitchVariantsProps>({ intent: "primar
 
 
 const SwitchRoot = React.forwardRef<
-  React.ElementRef<typeof Switch.Root>,
+  React.ComponentRef<typeof Switch.Root>,
   React.ComponentPropsWithoutRef<typeof Switch.Root> & SwitchVariantsProps
   >(({ className, intent="primary", fancy=false, ...props }, forwardedRef) => {
     const { root } = fancy ? fancySwitch({intent}) : switchTheme({intent});
@@ -21,7 +21,7 @@ const SwitchRoot = React.forwardRef<
   });
 
 const SwitchThumb = React.forwardRef<
-  React.ElementRef<typeof Switch.Thumb>,
+  React.ComponentRef<typeof Switch.Thumb>,
   React.ComponentPropsWithoutRef<typeof Switch.Thumb> & SwitchProps
   >(({ className, ...props }, forwardedRef) => {
     const { intent } = useContext(SwitchContext)

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -17,7 +17,7 @@ const TabsContext = React.createContext<Omit<ListProps, "variant">>({
 const TabsRoot = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & ListProps
   >(({ className, variant="bottomOutlined", triggerVariant="plain", intent="primary", size="md", ...props }, forwardedRef) => {
 
@@ -35,7 +35,7 @@ const TabsList = React.forwardRef<
 });
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentRef<typeof TabsPrimitive.Trigger>,
   React.ComponentProps<typeof TabsPrimitive.Trigger>
 >(({className, ...props}, forwardedRef) => {
 
@@ -51,7 +51,7 @@ const TabsTrigger = React.forwardRef<
 });
 
 const TabsIndicator = React.forwardRef<
-  React.ElementRef<"span">,
+  React.ComponentRef<"span">,
   React.ComponentProps<"span"> & Pick<IndicatorProps, "variant">
   >(({ className, variant = "bottom", ...props }, forwardedRef) => {
   

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -9,7 +9,7 @@ const ToastAction = ToastPrimitive.Action;
 const ToastClose = ToastPrimitive.Close;
 
 const ToastRoot = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitive.Root>,
+  React.ComponentRef<typeof ToastPrimitive.Root>,
   React.ComponentProps<typeof ToastPrimitive.Root> & ToastProps
   >(({fancy=false, mixed=false, withAction=false, className, ...props}, forwardedRef) => {
     
@@ -27,7 +27,7 @@ const ToastRoot = React.forwardRef<
 });
 
 const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitive.Title>,
+  React.ComponentRef<typeof ToastPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitive.Title>
 >((props, forwardedRef) => {
   return (
@@ -40,7 +40,7 @@ const ToastTitle = React.forwardRef<
 });
 
 const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitive.Description>,
+  React.ComponentRef<typeof ToastPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitive.Description>
 >((props, forwardedRef) => {
   return (
@@ -53,7 +53,7 @@ const ToastDescription = React.forwardRef<
 });
 
 const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitive.Viewport>,
+  React.ComponentRef<typeof ToastPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitive.Viewport>
 >((props, forwardedRef) => {
   return (

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -6,7 +6,7 @@ import { toggle, type ToggleRootProps, type ToggleIconProps as ToggleIconVariant
 const {root, icon} = toggle();
 
 const ToggleRoot = React.forwardRef<
-  React.ElementRef<typeof Root>,
+  React.ComponentRef<typeof Root>,
   React.ComponentPropsWithoutRef<typeof Root> & ToggleRootProps
 >(({
      className,

--- a/src/components/toggle_group/ToggleGroup.tsx
+++ b/src/components/toggle_group/ToggleGroup.tsx
@@ -12,7 +12,7 @@ const RootContext = createContext<ToggleRootProps>({
 });
 
 const ToggleGroupRoot = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> & ToggleRootProps
 >((
   {
@@ -33,7 +33,7 @@ const ToggleGroupRoot = React.forwardRef<
 
 // Creating the ToggleGroupItem component with forwardRef to pass the ref
 const ToggleGroupItem = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> & ToggleRootProps
 >((
   {

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -9,7 +9,7 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 const TooltipPortal = TooltipPrimitive.Portal;
 
 const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & TooltipProps
   >(({ className, fancy=false, inverted=false, sideOffset = 4, ...props }, ref) => {
     


### PR DESCRIPTION
This pull request updates multiple components across the codebase to replace `React.ElementRef` with `React.ComponentRef` in `React.forwardRef` definitions. This change ensures better type compatibility and aligns with updated React typings. The changes span components such as Accordion, AlertDialog, Avatar, Checkbox, ContextMenu, Dialog, Drawer, and DropdownMenu.

### Accordion Component Updates:
* Replaced `React.ElementRef` with `React.ComponentRef` in `AccordionRoot`, `AccordionItem`, `AccordionTrigger`, and `AccordionContent` definitions for improved type compatibility. (`src/components/accordion/Accordion.tsx`, [[1]](diffhunk://#diff-df14e251b9e849c330152843bea7805f5894dfaf3d2716ae9b38814c809ea85aL10-R10) [[2]](diffhunk://#diff-df14e251b9e849c330152843bea7805f5894dfaf3d2716ae9b38814c809ea85aL26-R26) [[3]](diffhunk://#diff-df14e251b9e849c330152843bea7805f5894dfaf3d2716ae9b38814c809ea85aL49-R49) [[4]](diffhunk://#diff-df14e251b9e849c330152843bea7805f5894dfaf3d2716ae9b38814c809ea85aL72-R72)

### AlertDialog Component Updates:
* Updated `React.forwardRef` definitions for `AlertDialogOverlay`, `AlertDialogContent`, `AlertDialogTitle`, `AlertDialogDescription`, and `AlertDialogActions` to use `React.ComponentRef` instead of `React.ElementRef`. (`src/components/alert_dialog/AlertDialog.tsx`, [[1]](diffhunk://#diff-e9b0744dd9e5db6d909cadd7398a91cf496c23be6265a8ea9996f149244d2813L26-R26) [[2]](diffhunk://#diff-e9b0744dd9e5db6d909cadd7398a91cf496c23be6265a8ea9996f149244d2813L41-R41) [[3]](diffhunk://#diff-e9b0744dd9e5db6d909cadd7398a91cf496c23be6265a8ea9996f149244d2813L61-R61) [[4]](diffhunk://#diff-e9b0744dd9e5db6d909cadd7398a91cf496c23be6265a8ea9996f149244d2813L85-R85) [[5]](diffhunk://#diff-e9b0744dd9e5db6d909cadd7398a91cf496c23be6265a8ea9996f149244d2813L112-R112)

### Avatar Component Updates:
* Adjusted `React.forwardRef` definitions for `AvatarRoot`, `AvatarFallback`, and `AvatarImage` to replace `React.ElementRef` with `React.ComponentRef`. (`src/components/avatar/Avatar.tsx`, [[1]](diffhunk://#diff-585ee2d477043ed7aa6f323f519ba8822c769133ad35a9215c8a25659c53fb7dL6-R6) [[2]](diffhunk://#diff-585ee2d477043ed7aa6f323f519ba8822c769133ad35a9215c8a25659c53fb7dL22-R22) [[3]](diffhunk://#diff-585ee2d477043ed7aa6f323f519ba8822c769133ad35a9215c8a25659c53fb7dL35-R35)

### ContextMenu Component Updates:
* Updated `React.forwardRef` definitions for `ContextMenuTrigger`, `ContextMenuContent`, `ContextMenuItem`, `ContextMenuSubTrigger`, `ContextMenuSubContent`, `ContextMenuSeparator`, `ContextMenuCommand`, and `ContextMenuIcon` to use `React.ComponentRef`. (`src/components/context_menu/ContextMenu.tsx`, [[1]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L26-R26) [[2]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L40-R40) [[3]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L73-R73) [[4]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L106-R106) [[5]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L138-R138) [[6]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L171-R171) [[7]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L189-R189) [[8]](diffhunk://#diff-9d4de9339c6852684ebfc8777134dce9621de4e2e123649d348caf2552482bd2L203-R203)

### Dialog Component Updates:
* Modified `React.forwardRef` definitions for `DialogOverlay`, `DialogContent`, `DialogTitle`, `DialogDescription`, and `DialogActions` to use `React.ComponentRef`. (`src/components/dialog/Dialog.tsx`, [[1]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0L22-R22) [[2]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0L38-R38) [[3]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0L57-R57) [[4]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0L79-R79) [[5]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0L102-R102)

### Drawer Component Updates:
* Replaced `React.ElementRef` with `React.ComponentRef` in `Root`, `Content`, `Overlay`, `Title`, and `Description` definitions. (`src/components/drawer/Drawer.tsx`, [[1]](diffhunk://#diff-d16091feb2231710877f9542b0dca46d2b814e76e1f6136a831263c3217b1f05L24-R24) [[2]](diffhunk://#diff-d16091feb2231710877f9542b0dca46d2b814e76e1f6136a831263c3217b1f05L36-R36) [[3]](diffhunk://#diff-d16091feb2231710877f9542b0dca46d2b814e76e1f6136a831263c3217b1f05L61-R61) [[4]](diffhunk://#diff-d16091feb2231710877f9542b0dca46d2b814e76e1f6136a831263c3217b1f05L77-R77) [[5]](diffhunk://#diff-d16091feb2231710877f9542b0dca46d2b814e76e1f6136a831263c3217b1f05L92-R92)

### DropdownMenu Component Updates:
* Updated `React.forwardRef` definitions for `DropdownMenuContent`, `DropdownMenuItem`, and `DropdownMenuSeparator` to use `React.ComponentRef`. (`src/components/dropdown_menu/DropdownMenu.tsx`, [[1]](diffhunk://#diff-5712e528ae0edc1a040c615a6b75dc42cd4bab7d1dbe9a639435e44780cc71c0L25-R25) [[2]](diffhunk://#diff-5712e528ae0edc1a040c615a6b75dc42cd4bab7d1dbe9a639435e44780cc71c0L60-R60) [[3]](diffhunk://#diff-5712e528ae0edc1a040c615a6b75dc42cd4bab7d1dbe9a639435e44780cc71c0L81-R81)